### PR TITLE
Hash update is now working again

### DIFF
--- a/src/index.es6
+++ b/src/index.es6
@@ -122,7 +122,7 @@ export default function bootstrap ({
 
   // UPSTREAM
   // updateLocation :: (IFrameDOMElement -> String) -> Array IFrameDOMElement -> Effect context
-  const updateLocation = () => history.pushState({}, context.document.title, generateHash(id)(iframes)())
+  const updateLocation = ( event ) => history.pushState({}, context.document.title, generateHash(id)([event.target.frameElement])())
 
   // bindRouting :: iframe -> Effect iframe
   const bindRouting = iframe => {


### PR DESCRIPTION
The context of the execution of the updateLocation function is living INSIDE the iFrame, and because of that the iframes object is not available ( set to undefined ).
Therefore the usage of the event object is highly suggested. Wrap it into an array to keep the code flowing as the function expects an iterable object.